### PR TITLE
Driver version 18.0.0f0 and correction of bugs

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,3 +27,8 @@ More information can be found on [ni.com](http://www.ni.com/virtualbench/).
     + pip install pywinusb
     + pip install Pyglet
     + copy `./support/avbin-win32-5.zip/avbin.dll` into your `c:\Windows\System32` directory
+
+## Helpful Resources
+* [NI support article on pyVirtualBench](https://knowledge.ni.com/KnowledgeArticleDetails?id=kA00Z000000kHUFSA2)
+* VirtualBench C library is found in `C:\Program Files (x86)\National Instruments\Shared\ExternalCompilerSupport\C`
+* Examples for the C-API of VirtualBench are found in `C:\Users\Public\Documents\National Instruments\VirtualBench ANSI C Examples`

--- a/lib/nivirtualbench.h
+++ b/lib/nivirtualbench.h
@@ -1,7 +1,7 @@
 /*============================================================================*/
 /*                  National Instruments / VirtualBench API                   */
 /*----------------------------------------------------------------------------*/
-/*    Copyright (c) National Instruments 2014-2016.  All Rights Reserved.     */
+/*    Copyright (c) National Instruments 2014-2018.  All Rights Reserved.     */
 /*----------------------------------------------------------------------------*/
 /*                                                                            */
 /* Title:   nivirtualbench.h                                                  */
@@ -271,6 +271,7 @@ typedef enum NIVB_ENUM_TYPE {
 
 typedef enum NIVB_ENUM_TYPE {
    niVB_Status_Success = 0,
+   niVB_Status_ErrorCalFunctionNotSupported = -375995,
    niVB_Status_ErrorInputTerminationOverloaded = -375993,
    niVB_Status_ErrorArbClipping = -375992,
    niVB_Status_ErrorInvalidOperationForMultipleChansEdgeTrigger = -375991,
@@ -420,7 +421,7 @@ typedef struct {
 #define NIVB_DECL
 #endif
 
-#define NIVB_LIBRARY_VERSION 253804545
+#define NIVB_LIBRARY_VERSION 302039040
 
 /*
  * Initialize the VirtualBench library.  This must be called at least once for
@@ -921,6 +922,13 @@ niVB_Status NIVB_DECL niVB_FGEN_QueryGenerationStatus(
  * Transitions the session from the Stopped state to the Running state.
  */
 niVB_Status NIVB_DECL niVB_FGEN_Run(
+   niVB_FGEN_InstrumentHandle instrumentHandle);
+
+/*
+ * Performs offset nulling calibration on the device. You must run FGEN 
+ * Initialize prior to running this method.
+ */
+niVB_Status NIVB_DECL niVB_FGEN_SelfCalibrate(
    niVB_FGEN_InstrumentHandle instrumentHandle);
 
 /*

--- a/lib/pyvirtualbench.py
+++ b/lib/pyvirtualbench.py
@@ -25,7 +25,7 @@
 from ctypes import c_bool, c_size_t, c_double, c_uint8, c_int32, c_uint32, c_int64, c_uint64, c_wchar, c_wchar_p, Structure, c_int, cdll, byref
 from enum import IntEnum
 
-NIVB_LIBRARY_VERSION = 253804545 # 0x0F20C001 15.2.0f0
+NIVB_LIBRARY_VERSION = 302039040 # 18.0.0f0, is found in nivirtualbench.h
 
 class Language(IntEnum):
     CURRENT_THREAD_LOCALE = 0
@@ -226,6 +226,7 @@ class I2cClockRate(IntEnum):
 
 class Status(IntEnum):
     SUCCESS = 0
+    niVB_Status_ErrorCalFunctionNotSupported = -375995
     ERROR_INPUT_TERMINATION_OVERLOADED = -375993
     ERROR_ARB_CLIPPING = -375992
     ERROR_INVALID_OPERATION_FOR_MULTIPLE_CHANS_EDGE_TRIGGER = -375991
@@ -757,6 +758,14 @@ class PyVirtualBench:
             if (status != Status.SUCCESS):
                 raise PyVirtualBenchException(status, self.nilcicapi, self.library_handle)
 
+        def self_calibrate(self):
+            '''Performs offset nulling calibration on the device. You must run FGEN
+               Initialize prior to running this method.
+            '''
+            status = self.nilcicapi.niVB_FGEN_SelfCalibrate(self.instrument_handle)
+            if (status != Status.SUCCESS):
+                raise PyVirtualBenchException(status, self.nilcicapi, self.library_handle)
+        
         def stop(self):
             ''' Transitions the acquisition from either the Triggered or Running
                 state to the Stopped state.

--- a/lib/pyvirtualbench.py
+++ b/lib/pyvirtualbench.py
@@ -666,16 +666,16 @@ class PyVirtualBench:
             if (status != Status.SUCCESS):
                 raise PyVirtualBenchException(status, self.nilcicapi, self.library_handle)
 
-        def configure_arbitrary_waveform(self, waveform_size, sample_period):
+        def configure_arbitrary_waveform(self, waveform, sample_period):
             ''' Configures the instrument to output a waveform. The waveform is
                 output either after the end of the current waveform if output
                 is enabled, or immediately after output is enabled.
             '''
-            waveform = (c_double * waveform_size)()
-            status = self.nilcicapi.niVB_FGEN_ConfigureArbitraryWaveform(self.instrument_handle, byref(waveform), c_size_t(waveform_size), c_double(sample_period))
+            waveform_size = len(waveform)
+            waveform = (c_double * waveform_size)(*waveform)
+            status = self.nilcicapi.niVB_FGEN_ConfigureArbitraryWaveform(self.instrument_handle, waveform, c_size_t(waveform_size), c_double(sample_period))
             if (status != Status.SUCCESS):
                 raise PyVirtualBenchException(status, self.nilcicapi, self.library_handle)
-            return waveform.value
 
         def configure_arbitrary_waveform_gain_and_offset(self, gain, dc_offset):
             ''' Configures the instrument to output an arbitrary waveform with a

--- a/lib/pyvirtualbench.py
+++ b/lib/pyvirtualbench.py
@@ -443,7 +443,7 @@ class PyVirtualBench:
         status = self.nilcicapi.niVB_CollapseChannelStringW(self.library_handle, c_wchar_p(names_in), None, c_size_t(0), byref(names_out_size_out), None)
         if (status != Status.SUCCESS):
             raise PyVirtualBenchException(status, self.nilcicapi, self.library_handle)
-        names_out_size = c_size_t(names_out_size_out.value)
+        names_out_size = names_out_size_out.value
         names_out = (c_wchar * names_out_size)()
         number_of_channels = c_size_t(0)
         status = self.nilcicapi.niVB_CollapseChannelStringW(self.library_handle, c_wchar_p(names_in), byref(names_out), c_size_t(names_out_size), None, byref(number_of_channels))
@@ -459,7 +459,7 @@ class PyVirtualBench:
         status = self.nilcicapi.niVB_ExpandChannelStringW(self.library_handle, c_wchar_p(names_in), None, c_size_t(0), byref(names_out_size_out), None)
         if (status != Status.SUCCESS):
             raise PyVirtualBenchException(status, self.nilcicapi, self.library_handle)
-        names_out_size = c_size_t(names_out_size_out.value)
+        names_out_size = names_out_size_out.value
         names_out = (c_wchar * names_out_size)()
         number_of_channels = c_size_t(0)
         status = self.nilcicapi.niVB_ExpandChannelStringW(self.library_handle, c_wchar_p(names_in), byref(names_out), c_size_t(names_out_size), None, byref(number_of_channels))
@@ -1196,7 +1196,7 @@ class PyVirtualBench:
             status = self.nilcicapi.niVB_MSO_QueryAnalogEdgeTriggerW(self.instrument_handle, c_int32(trigger_instance), None, c_size_t(0), byref(trigger_source_size_out), byref(trigger_slope), byref(trigger_level), byref(trigger_hysteresis))
             if (status != Status.SUCCESS):
                 raise PyVirtualBenchException(status, self.nilcicapi, self.library_handle)
-            trigger_source_size = c_size_t(trigger_source_size_out.value)
+            trigger_source_size = trigger_source_size_out.value
             trigger_source = (c_wchar * trigger_source_size)()
             status = self.nilcicapi.niVB_MSO_QueryAnalogEdgeTriggerW(self.instrument_handle, c_int32(trigger_instance), byref(trigger_source), c_size_t(trigger_source_size), byref(trigger_source_size_out), byref(trigger_slope), byref(trigger_level), byref(trigger_hysteresis))
             if (status != Status.SUCCESS):
@@ -1212,7 +1212,7 @@ class PyVirtualBench:
             status = self.nilcicapi.niVB_MSO_QueryDigitalEdgeTriggerW(self.instrument_handle, c_int32(trigger_instance), None, c_size_t(0), byref(trigger_source_size_out), byref(trigger_slope))
             if (status != Status.SUCCESS):
                 raise PyVirtualBenchException(status, self.nilcicapi, self.library_handle)
-            trigger_source_size = c_size_t(trigger_source_size_out.value)
+            trigger_source_size = trigger_source_size_out.value
             trigger_source = (c_wchar * trigger_source_size)()
             status = self.nilcicapi.niVB_MSO_QueryDigitalEdgeTriggerW(self.instrument_handle, c_int32(trigger_instance), byref(trigger_source), c_size_t(trigger_source_size), byref(trigger_source_size_out), byref(trigger_slope))
             if (status != Status.SUCCESS):
@@ -1232,9 +1232,9 @@ class PyVirtualBench:
             status = self.nilcicapi.niVB_MSO_QueryDigitalPatternTriggerW(self.instrument_handle, c_int32(trigger_instance), None, c_size_t(0), byref(trigger_source_size_out), None, c_size_t(0), byref(trigger_pattern_size_out))
             if (status != Status.SUCCESS):
                 raise PyVirtualBenchException(status, self.nilcicapi, self.library_handle)
-            trigger_source_size = c_size_t(trigger_source_size_out.value)
+            trigger_source_size = trigger_source_size_out.value
             trigger_source = (c_wchar * trigger_source_size)()
-            trigger_pattern_size = c_size_t(trigger_pattern_size_out.value)
+            trigger_pattern_size = trigger_pattern_size_out.value
             trigger_pattern = (c_wchar * trigger_pattern_size)()
             status = self.nilcicapi.niVB_MSO_QueryDigitalPatternTriggerW(self.instrument_handle, c_int32(trigger_instance), byref(trigger_source), c_size_t(trigger_source_size), byref(trigger_source_size_out), byref(trigger_pattern), c_size_t(trigger_pattern_size), byref(trigger_pattern_size_out))
             if (status != Status.SUCCESS):
@@ -1251,7 +1251,7 @@ class PyVirtualBench:
             status = self.nilcicapi.niVB_MSO_QueryDigitalGlitchTriggerW(self.instrument_handle, c_int32(trigger_instance), None, c_size_t(0), byref(trigger_source_size_out))
             if (status != Status.SUCCESS):
                 raise PyVirtualBenchException(status, self.nilcicapi, self.library_handle)
-            trigger_source_size = c_size_t(trigger_source_size_out.value)
+            trigger_source_size = trigger_source_size_out.value
             trigger_source = (c_wchar * trigger_source_size)()
             status = self.nilcicapi.niVB_MSO_QueryDigitalGlitchTriggerW(self.instrument_handle, c_int32(trigger_instance), byref(trigger_source), c_size_t(trigger_source_size), byref(trigger_source_size_out))
             if (status != Status.SUCCESS):
@@ -1280,7 +1280,7 @@ class PyVirtualBench:
             status = self.nilcicapi.niVB_MSO_QueryAnalogPulseWidthTriggerW(self.instrument_handle, c_int32(trigger_instance), None, c_size_t(0), byref(trigger_source_size_out), byref(trigger_polarity), byref(trigger_level), byref(comparison_mode), byref(lower_limit), byref(upper_limit))
             if (status != Status.SUCCESS):
                 raise PyVirtualBenchException(status, self.nilcicapi, self.library_handle)
-            trigger_source_size = c_size_t(trigger_source_size_out.value)
+            trigger_source_size = trigger_source_size_out.value
             trigger_source = (c_wchar * trigger_source_size)()
             status = self.nilcicapi.niVB_MSO_QueryAnalogPulseWidthTriggerW(self.instrument_handle, c_int32(trigger_instance), byref(trigger_source), c_size_t(trigger_source_size), byref(trigger_source_size_out), byref(trigger_polarity), byref(trigger_level), byref(comparison_mode), byref(lower_limit), byref(upper_limit))
             if (status != Status.SUCCESS):
@@ -1300,7 +1300,7 @@ class PyVirtualBench:
             status = self.nilcicapi.niVB_MSO_QueryDigitalPulseWidthTriggerW(self.instrument_handle, c_int32(trigger_instance), None, c_size_t(0), byref(trigger_source_size_out), byref(trigger_polarity), byref(comparison_mode), byref(lower_limit), byref(upper_limit))
             if (status != Status.SUCCESS):
                 raise PyVirtualBenchException(status, self.nilcicapi, self.library_handle)
-            trigger_source_size = c_size_t(trigger_source_size_out.value)
+            trigger_source_size = trigger_source_size_out.value
             trigger_source = (c_wchar * trigger_source_size)()
             status = self.nilcicapi.niVB_MSO_QueryDigitalPulseWidthTriggerW(self.instrument_handle, c_int32(trigger_instance), byref(trigger_source), c_size_t(trigger_source_size), byref(trigger_source_size_out), byref(trigger_polarity), byref(comparison_mode), byref(lower_limit), byref(upper_limit))
             if (status != Status.SUCCESS):

--- a/lib/pyvirtualbench.py
+++ b/lib/pyvirtualbench.py
@@ -1984,7 +1984,7 @@ class PyVirtualBench:
             status = self.nilcicapi.niVB_PS_QueryVoltageOutputW(self.instrument_handle, channel, byref(voltage_level), byref(current_limit))
             if (status != Status.SUCCESS):
                 raise PyVirtualBenchException(status, self.nilcicapi, self.library_handle)
-            return voltage_level, current_limit
+            return voltage_level.value, current_limit.value
 
         def query_current_output(self, channel):
             ''' Indicates the current output settings on the specified channel.
@@ -1994,7 +1994,7 @@ class PyVirtualBench:
             status = self.nilcicapi.niVB_PS_QueryCurrentOutputW(self.instrument_handle, channel, byref(current_level), byref(voltage_limit))
             if (status != Status.SUCCESS):
                 raise PyVirtualBenchException(status, self.nilcicapi, self.library_handle)
-            return current_level, voltage_limit
+            return current_level.value, voltage_limit.value
 
         def query_outputs_enabled(self):
             ''' Indicates whether the outputs are enabled for the instrument.

--- a/lib/pyvirtualbench.py
+++ b/lib/pyvirtualbench.py
@@ -1068,7 +1068,7 @@ class PyVirtualBench:
             vertical_offset = c_double(0)
             probe_attenuation = c_int32(0)
             vertical_coupling = c_int32(0)
-            status = self.nilcicapi.niVB_MSO_QueryAnalogChannelW(self.instrument_handle, c_wchar_p(channel), byref(channel_enabled), byref(vertical_range), byref(vertical_offset), byref(probe_attenuation), c_int32(vertical_coupling))
+            status = self.nilcicapi.niVB_MSO_QueryAnalogChannelW(self.instrument_handle, c_wchar_p(channel), byref(channel_enabled), byref(vertical_range), byref(vertical_offset), byref(probe_attenuation), byref(vertical_coupling))
             if (status != Status.SUCCESS):
                 raise PyVirtualBenchException(status, self.nilcicapi, self.library_handle)
             return channel_enabled.value, vertical_range.value, vertical_offset.value, MsoProbeAttenuation(probe_attenuation.value), MsoCoupling(vertical_coupling.value)


### PR DESCRIPTION
Hello,

first of all thank you for this extensive library and the included examples. It is a great help!

I updated the header file to driver version 18.0.0f0 which is the current version from NI's website. One new function was added (FGEN self calibration).

Apart from that, I fixed some type errors, mainly related to the "size" variables inside the methods. There was some doubling of calling `c_size_t`.